### PR TITLE
Fix broken keyboard input by adding topology.xml

### DIFF
--- a/game.libretro.o2em/resources/topology.xml
+++ b/game.libretro.o2em/resources/topology.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logicaltopology>
+  <port type="keyboard">
+    <accepts controller="game.controller.keyboard"/>
+  </port>
+  <port type="controller" id="1">
+    <accepts controller="game.controller.odyssey2"/>
+  </port>
+</logicaltopology>


### PR DESCRIPTION
By default, if no topology is present, it'll assume a single controller
port that accepts the controllers imported by addon.xml.

If a keyboard is required, this must be specified in topology.xml.